### PR TITLE
Fix newline persistence in task details editor

### DIFF
--- a/task.php
+++ b/task.php
@@ -187,7 +187,10 @@ if ($p < 0 || $p > 3) { $p = 0; }
   const detailsField = document.getElementById('detailsField');
   if (details && detailsField) {
       updateDetails = function() {
-        detailsField.value = details.textContent;
+        const text = details.innerText
+          .replace(/\r\n/g, "\n")
+          .replace(/\r/g, "\n");
+        detailsField.value = text;
       };
       details.addEventListener('input', function(){
         updateDetails();


### PR DESCRIPTION
## Summary
- update the auto-save helper for the task details editor to capture the element's innerText
- normalize carriage returns to line feeds before storing the hidden field value so multiline notes persist after reloads

## Testing
- php -l task.php

------
https://chatgpt.com/codex/tasks/task_e_68da801c2e1c832bb0322d38eb60e9cc