### PR TITLE
Block Ctrl+S save shortcut across pages

### DIFF
--- a/completed.php
+++ b/completed.php
@@ -122,6 +122,7 @@ $tomorrowFmt = $tomorrow->format('Y-m-d');
     </div>
     <?php endif; ?>
 </div>
+<script src="prevent-save-shortcut.js"></script>
 <script src="sw-register.js"></script>
 <script src="sync-status.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/index.php
+++ b/index.php
@@ -162,6 +162,7 @@ $tomorrowFmt = $tomorrow->format('Y-m-d');
         <?php endforeach; ?>
     </div>
 </div>
+<script src="prevent-save-shortcut.js"></script>
 <script src="sw-register.js"></script>
 <script src="sync-status.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/login.php
+++ b/login.php
@@ -56,6 +56,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </form>
     <p>Don't have an account? <a href="register.php">Register</a></p>
 </div>
+<script src="prevent-save-shortcut.js"></script>
 <script src="sw-register.js"></script>
 </body>
 </html>

--- a/prevent-save-shortcut.js
+++ b/prevent-save-shortcut.js
@@ -1,0 +1,10 @@
+(function() {
+  function blockSaveShortcut(event) {
+    if ((event.ctrlKey || event.metaKey) && (event.key === 's' || event.key === 'S')) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
+  window.addEventListener('keydown', blockSaveShortcut, { capture: true });
+})();

--- a/register.php
+++ b/register.php
@@ -52,6 +52,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </form>
     <p>Already have an account? <a href="login.php">Login</a></p>
 </div>
+<script src="prevent-save-shortcut.js"></script>
 <script src="sw-register.js"></script>
 </body>
 </html>

--- a/settings.php
+++ b/settings.php
@@ -129,6 +129,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <a href="index.php" class="btn btn-secondary">Back</a>
     </form>
 </div>
+<script src="prevent-save-shortcut.js"></script>
 <script src="sw-register.js"></script>
 <script src="sync-status.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/task.php
+++ b/task.php
@@ -190,6 +190,7 @@ if ($p < 0 || $p > 3) { $p = 0; }
         <p class="text-muted mt-2 d-none" id="nextTaskMessage"></p>
     </form>
 </div>
+<script src="prevent-save-shortcut.js"></script>
 <script src="sync-status.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- add a shared script that blocks Ctrl+S/Cmd+S to prevent the browser save dialog
- include the script on login, registration, tasks, settings, and list views

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a74dcf724832baa7ff42b954d6904)