### PR TITLE
Hide SQLite database file across platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-database.sqlite
+.database.sql

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ A simple PHP online todo list application with user authentication and SQLite st
    ```
 3. Open <http://localhost:8000/login.php> in your browser to register and start using the app.
 
-The application will create `database.sqlite` in the project directory on first run.
+The application will create a hidden `.database.sql` file in the project directory on first run.

--- a/db.php
+++ b/db.php
@@ -4,7 +4,14 @@ session_start();
 function get_db() {
     static $db = null;
     if ($db === null) {
-        $db = new PDO('sqlite:' . __DIR__ . '/database.sqlite');
+        $databaseFile = __DIR__ . '/.database.sql';
+        $legacyDatabaseFile = __DIR__ . '/database.sqlite';
+
+        if (!file_exists($databaseFile) && file_exists($legacyDatabaseFile)) {
+            rename($legacyDatabaseFile, $databaseFile);
+        }
+
+        $db = new PDO('sqlite:' . $databaseFile);
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         $db->exec("CREATE TABLE IF NOT EXISTS users (
@@ -49,6 +56,10 @@ function get_db() {
         }
         if (!in_array('default_priority', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN default_priority INTEGER NOT NULL DEFAULT 0');
+        }
+
+        if (PHP_OS_FAMILY === 'Windows' && file_exists($databaseFile)) {
+            exec('attrib +h ' . escapeshellarg($databaseFile));
         }
     }
     return $db;


### PR DESCRIPTION
## Summary
- change SQLite file name to hidden `.database.sql`, migrating any existing `database.sqlite`
- set hidden attribute on Windows deployments using `attrib +h` when the database exists
- update documentation and ignore rules for the new hidden database file

## Testing
- php -l db.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e2aad7e20832b8e7d0a5310e48388)