### PR TITLE
Use range-based insertion for task details

### DIFF
--- a/__tests__/task-details.test.js
+++ b/__tests__/task-details.test.js
@@ -24,21 +24,6 @@ describe('task details editor behaviors', () => {
       <div id="detailsInput" contenteditable="true"></div>
       <input id="detailsField" type="hidden" />
     `;
-
-    document.execCommand = jest.fn((command, _ui, value) => {
-      if (command !== 'insertText') return false;
-      const selection = window.getSelection();
-      if (!selection || selection.rangeCount === 0) return false;
-      const range = selection.getRangeAt(0);
-      range.deleteContents();
-      const textNode = document.createTextNode(value);
-      range.insertNode(textNode);
-      range.setStart(textNode, textNode.length);
-      range.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(range);
-      return true;
-    });
   });
 
   test('normalizes newlines and syncs hidden field', () => {

--- a/task-details.js
+++ b/task-details.js
@@ -5,17 +5,13 @@
 
   function insertTextAtSelection(text) {
     if (!text) return;
-    if (typeof document.execCommand === 'function') {
-      document.execCommand('insertText', false, text);
-      return;
-    }
     const sel = window.getSelection && window.getSelection();
     if (!sel || sel.rangeCount === 0) return;
     const range = sel.getRangeAt(0);
     range.deleteContents();
     const textNode = document.createTextNode(text);
     range.insertNode(textNode);
-    range.setStart(textNode, textNode.length);
+    range.setStartAfter(textNode);
     range.collapse(true);
     sel.removeAllRanges();
     sel.addRange(range);


### PR DESCRIPTION
## Summary
- replace execCommand-based text insertion with Selection/Range handling for consistent newline insertion
- simplify task detail editor tests now that browser command stubbing is no longer needed

## Testing
- npm test -- --runInBand *(fails: jest not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693188b774ec832b9a7825206ab6ab2c)