### PR TITLE
Add prism-based editor for task descriptions

### DIFF
--- a/__tests__/task-details.test.js
+++ b/__tests__/task-details.test.js
@@ -95,13 +95,13 @@ describe('task details editor behaviors', () => {
     expect(preview.innerHTML).not.toContain('</div>\n<div');
   });
 
-  test('line coloring ignores leading whitespace and supports milestone lines', () => {
+  test('line coloring ignores leading whitespace and supports milestone/heading/done lines', () => {
     const details = document.getElementById('detailsInput');
     const textarea = details.querySelector('textarea');
     const hidden = document.getElementById('detailsField');
     const editor = initTaskDetailsEditor(details, hidden, jest.fn());
 
-    textarea.value = '  T first task\n\tN note line\n    M milestone\nplain';
+    textarea.value = '  T first task\n\tN note line\n    M milestone\n  # heading\n\tX done\nplain';
     editor.updateDetails();
 
     const preview = details.querySelector('code');
@@ -110,7 +110,9 @@ describe('task details editor behaviors', () => {
     expect(lines[0].classList.contains('code-line-task')).toBe(true);
     expect(lines[1].classList.contains('code-line-note')).toBe(true);
     expect(lines[2].classList.contains('code-line-milestone')).toBe(true);
-    expect(lines[3].classList.length).toBe(1);
+    expect(lines[3].classList.contains('code-line-heading')).toBe(true);
+    expect(lines[4].classList.contains('code-line-done')).toBe(true);
+    expect(lines[5].classList.length).toBe(1);
   });
 
   test('syncing details does not force inline heights', () => {

--- a/task-details.js
+++ b/task-details.js
@@ -33,6 +33,10 @@
         classes.push('code-line-note');
       } else if (trimmed.startsWith('M ')) {
         classes.push('code-line-milestone');
+      } else if (trimmed.startsWith('# ')) {
+        classes.push('code-line-heading');
+      } else if (trimmed.startsWith('X ')) {
+        classes.push('code-line-done');
       }
       const content = line === '' ? '&#8203;' : line;
       return '<div class="' + classes.join(' ') + '">' + content + '</div>';

--- a/task.php
+++ b/task.php
@@ -166,6 +166,12 @@ if ($p < 0 || $p > 3) { $p = 0; }
         .prism-editor .code-line-milestone {
             color: #800000;
         }
+        .prism-editor .code-line-heading {
+            font-weight: 700;
+        }
+        .prism-editor .code-line-done {
+            color: #6c757d;
+        }
         .prism-editor .token.tag,
         .prism-editor .token.tag-name {
             color: #d63384;


### PR DESCRIPTION
## Summary
- replace the task description editor with a Prism-styled HTML code editor, including blue and green line coloring for prefixed lines
- update task detail scripting to sync the textarea-backed editor, highlighting, and hidden field values
- refresh tests to cover the new editor structure and interactions

## Testing
- Not run (Node.js runtime unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932aade1d28832bb40de59c3c4f4f3f)