### PR TITLE
Enable word wrap in task description editor

### DIFF
--- a/task.php
+++ b/task.php
@@ -134,7 +134,8 @@ if ($p < 0 || $p > 3) { $p = 0; }
             color: transparent;
             caret-color: var(--bs-body-color);
             overflow: hidden;
-            white-space: pre;
+            white-space: pre-wrap;
+            overflow-wrap: break-word;
             outline: none;
             z-index: 1;
             cursor: text;
@@ -143,7 +144,8 @@ if ($p < 0 || $p > 3) { $p = 0; }
             position: relative;
             margin: 0;
             pointer-events: none;
-            white-space: pre;
+            white-space: pre-wrap;
+            overflow-wrap: break-word;
             overflow: hidden;
             padding: 0.75rem;
             z-index: 0;


### PR DESCRIPTION
## Summary
- enable word wrap in the task description editor by allowing wrapped whitespace in the textarea and preview layers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c3a64a4c832bb259f67ffcef0b33)