### PR TITLE
Add customizable editor colors and line rules

### DIFF
--- a/__tests__/task-details.test.js
+++ b/__tests__/task-details.test.js
@@ -155,4 +155,24 @@ describe('task details editor behaviors', () => {
     expect(hidden.value).toBe('start paste');
     expect(saveSpy).toHaveBeenCalled();
   });
+
+  test('custom rules and text color settings are applied', () => {
+    const details = document.getElementById('detailsInput');
+    const textarea = details.querySelector('textarea');
+    const hidden = document.getElementById('detailsField');
+    const rules = [{ prefix: '!', label: 'Important', color: '#FF0000', className: 'custom-important', weight: '700' }];
+    const editor = initTaskDetailsEditor(details, hidden, jest.fn(), {
+      lineRules: rules,
+      textColor: '#123456'
+    });
+
+    textarea.value = '! urgent note';
+    editor.updateDetails();
+
+    const previewLine = details.querySelector('.code-line');
+    expect(previewLine.classList.contains('custom-important')).toBe(true);
+    expect(previewLine.style.getPropertyValue('color')).toBe('rgb(255, 0, 0)');
+    expect(previewLine.style.getPropertyValue('font-weight')).toBe('700');
+    expect(details.style.getPropertyValue('--details-text-color')).toBe('#123456');
+  });
 });

--- a/db.php
+++ b/db.php
@@ -24,7 +24,9 @@ function get_db() {
             username TEXT UNIQUE NOT NULL,
             password TEXT NOT NULL,
             location TEXT,
-            default_priority INTEGER NOT NULL DEFAULT 0
+            default_priority INTEGER NOT NULL DEFAULT 0,
+            line_rules TEXT,
+            details_color TEXT
         )");
 
         $db->exec("CREATE TABLE IF NOT EXISTS tasks (
@@ -61,6 +63,12 @@ function get_db() {
         }
         if (!in_array('default_priority', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN default_priority INTEGER NOT NULL DEFAULT 0');
+        }
+        if (!in_array('line_rules', $userColumns, true)) {
+            $db->exec('ALTER TABLE users ADD COLUMN line_rules TEXT');
+        }
+        if (!in_array('details_color', $userColumns, true)) {
+            $db->exec('ALTER TABLE users ADD COLUMN details_color TEXT');
         }
 
         if (PHP_OS_FAMILY === 'Windows' && file_exists($databaseFile)) {

--- a/line_rules.php
+++ b/line_rules.php
@@ -1,0 +1,74 @@
+<?php
+
+function get_default_line_rules() {
+    return [
+        ['prefix' => 'T ', 'label' => 'Task', 'color' => '#1D4ED8', 'className' => 'code-line-task'],
+        ['prefix' => 'N ', 'label' => 'Note', 'color' => '#1E7A3E', 'className' => 'code-line-note'],
+        ['prefix' => 'M ', 'label' => 'Milestone', 'color' => '#800000', 'className' => 'code-line-milestone'],
+        ['prefix' => '# ', 'label' => 'Heading', 'color' => '#212529', 'weight' => '700', 'className' => 'code-line-heading'],
+        ['prefix' => 'X ', 'label' => 'Done', 'color' => '#6C757D', 'className' => 'code-line-done'],
+    ];
+}
+
+function normalize_editor_color($color) {
+    $trimmed = strtoupper(trim($color ?? ''));
+    if (!preg_match('/^#[0-9A-F]{6}$/', $trimmed)) {
+        return '#212529';
+    }
+    return $trimmed;
+}
+
+function sanitize_line_rules($rules) {
+    if (!is_array($rules)) {
+        return [];
+    }
+
+    $cleaned = [];
+    foreach ($rules as $rule) {
+        if (!is_array($rule)) {
+            continue;
+        }
+        $prefix = isset($rule['prefix']) ? trim((string)$rule['prefix']) : '';
+        if ($prefix === '') {
+            continue;
+        }
+        $color = isset($rule['color']) ? strtoupper(trim((string)$rule['color'])) : null;
+        if ($color && !preg_match('/^#[0-9A-F]{6}$/', $color)) {
+            $color = null;
+        }
+        $label = isset($rule['label']) ? trim((string)$rule['label']) : '';
+        $weight = isset($rule['weight']) && in_array((string)$rule['weight'], ['400', '700'], true) ? (string)$rule['weight'] : null;
+
+        $className = isset($rule['className']) ? trim((string)$rule['className']) : '';
+        if ($className !== '' && !preg_match('/^[A-Za-z0-9_-]+$/', $className)) {
+            $className = '';
+        }
+
+        $cleaned[] = array_filter([
+            'prefix' => $prefix,
+            'label' => $label !== '' ? $label : null,
+            'color' => $color,
+            'weight' => $weight,
+            'className' => $className !== '' ? $className : null,
+        ], function ($value) {
+            return $value !== null && $value !== '';
+        });
+    }
+
+    return array_slice($cleaned, 0, 25);
+}
+
+function encode_line_rules_for_storage($rules) {
+    $sanitized = sanitize_line_rules($rules);
+    return json_encode($sanitized, JSON_UNESCAPED_SLASHES);
+}
+
+function decode_line_rules_from_storage($raw) {
+    $decoded = json_decode($raw ?? '', true);
+    $sanitized = sanitize_line_rules($decoded);
+    if (empty($sanitized)) {
+        $sanitized = get_default_line_rules();
+    }
+    return $sanitized;
+}
+

--- a/login.php
+++ b/login.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'db.php';
+require_once 'line_rules.php';
 
 if (isset($_SESSION['user_id'])) {
     header('Location: index.php');
@@ -13,7 +14,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($username === '' || $password === '') {
         $error = 'Please fill in all fields';
     } else {
-        $stmt = get_db()->prepare('SELECT id, password, location, default_priority FROM users WHERE username = :username');
+        $stmt = get_db()->prepare('SELECT id, password, location, default_priority, line_rules, details_color FROM users WHERE username = :username');
         $stmt->execute([':username' => $username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password'])) {
@@ -21,6 +22,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['username'] = $username;
             $_SESSION['location'] = $user['location'] ?? 'UTC';
             $_SESSION['default_priority'] = (int)($user['default_priority'] ?? 0);
+            $_SESSION['line_rules'] = decode_line_rules_from_storage($user['line_rules'] ?? '');
+            $_SESSION['details_color'] = normalize_editor_color($user['details_color'] ?? '#212529');
             header('Location: index.php');
             exit();
         } else {

--- a/register.php
+++ b/register.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'db.php';
+require_once 'line_rules.php';
 
 if (isset($_SESSION['user_id'])) {
     header('Location: index.php');
@@ -15,8 +16,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         try {
             $hash = password_hash($password, PASSWORD_DEFAULT);
-            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority) VALUES (:username, :password, 0)');
-            $stmt->execute([':username' => $username, ':password' => $hash]);
+            $defaultRules = encode_line_rules_for_storage(get_default_line_rules());
+            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority, line_rules, details_color) VALUES (:username, :password, 0, :rules, :color)');
+            $stmt->execute([
+                ':username' => $username,
+                ':password' => $hash,
+                ':rules' => $defaultRules,
+                ':color' => '#212529',
+            ]);
             header('Location: login.php');
             exit();
         } catch (PDOException $e) {


### PR DESCRIPTION
## Summary
- add settings fields so users can pick a task description text color and manage custom line prefix rules
- persist editor preferences per user and apply them when rendering the task details editor
- extend the editor logic to honor configurable rules and colors with updated coverage

## Testing
- npm test -- --runInBand *(fails: npm is not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c6c4b2d4832bb334b781f7085afd)