### PR TITLE
Update deployment workflow to target prod branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy via lftp
+
+on:
+  push:
+    branches: ["prod"]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install lftp
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lftp
+
+      - name: Deploy with lftp
+        env:
+          FTP_HOST: ${{ secrets.FTP_HOST }}
+          FTP_USER: ${{ secrets.FTP_USER }}
+          FTP_PASS: ${{ secrets.FTP_PASS }}
+          REMOTE_PATH: ${{ secrets.FTP_REMOTE_PATH }}
+        run: |
+          set -euo pipefail
+
+          : "${FTP_HOST:?FTP_HOST secret must be set}"
+          : "${FTP_USER:?FTP_USER secret must be set}"
+          : "${FTP_PASS:?FTP_PASS secret must be set}"
+
+          LOCAL_PATH="${GITHUB_WORKSPACE}"
+          REMOTE_PATH="${REMOTE_PATH:-/var/www/html}"
+
+          lftp -u "$FTP_USER","$FTP_PASS" "$FTP_HOST" <<EOF
+          set sftp:auto-confirm yes
+          set ftp:passive-mode on
+          set xfer:clobber on
+          lcd $LOCAL_PATH
+          cd $REMOTE_PATH
+          mirror -R \
+            --verbose \
+            --exclude-glob .git/* \
+            --exclude-glob .github/* \
+            --exclude-glob node_modules/* \
+            --exclude-glob __tests__/* \
+            --exclude-glob '*.log' \
+            --exclude-glob '*.md' \
+            --exclude .env \
+            .
+          bye
+          EOF

--- a/README.md
+++ b/README.md
@@ -24,3 +24,18 @@ A simple PHP online todo list application with user authentication and SQLite st
 3. Open <http://localhost:8000/login.php> in your browser to register and start using the app.
 
 The application will create a hidden `.database.sqlite` file in the project directory on first run.
+
+## Automated Deployment with GitHub Actions
+
+Use the included `.github/workflows/deploy.yml` workflow to deploy automatically whenever `prod` is updated.
+
+1. In your repository on GitHub, go to **Settings → Secrets and variables → Actions** and add:
+   - `FTP_HOST` – the hostname of your server.
+   - `FTP_USER` – the FTP/SFTP username.
+   - `FTP_PASS` – the FTP/SFTP password.
+   - `FTP_REMOTE_PATH` (optional) – destination path on the server. Defaults to `/var/www/html` if not set.
+2. Confirm your deployment branch is named `prod` or update `branches` in `.github/workflows/deploy.yml` to match your deploy branch.
+3. Commit and push changes. The workflow will install `lftp`, sync the repository to the remote path (excluding `.git`, `.github`, `node_modules`, tests, logs, and Markdown files), and run automatically on pushes to `prod`.
+4. For manual runs (e.g., urgent hotfixes), open **Actions → Deploy via lftp → Run workflow** to trigger `workflow_dispatch`.
+
+If you prefer SSH-based deployment instead of FTP/SFTP mirroring, you can adapt the deploy step to use `ssh` and run your server-side deploy script with the same secrets approach.


### PR DESCRIPTION
## Summary
- adjust GitHub Actions deploy workflow to trigger from the prod branch
- update README guidance to reference prod as the deployment branch

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693339d681a8832bbc5bd23d79df3528)