### PR TITLE
Preserve trailing spaces in custom line rules

### DIFF
--- a/__tests__/line_rules_test.php
+++ b/__tests__/line_rules_test.php
@@ -1,0 +1,19 @@
+<?php
+require __DIR__ . '/../line_rules.php';
+
+function assert_equal($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        fwrite(STDERR, "Assertion failed: {$message}\nExpected: " . var_export($expected, true) . "\nActual: " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}
+
+$rulesWithSpace = [['prefix' => 'T ', 'label' => 'Task', 'color' => '#123456']];
+$sanitized = sanitize_line_rules($rulesWithSpace);
+assert_equal('T ', $sanitized[0]['prefix'], 'sanitize_line_rules should preserve trailing whitespace');
+
+$encoded = encode_line_rules_for_storage($rulesWithSpace);
+$decoded = decode_line_rules_from_storage($encoded);
+assert_equal('T ', $decoded[0]['prefix'], 'round trip through encode/decode should keep trailing whitespace');
+
+echo "All PHP line rule tests passed\n";

--- a/line_rules.php
+++ b/line_rules.php
@@ -28,10 +28,11 @@ function sanitize_line_rules($rules) {
         if (!is_array($rule)) {
             continue;
         }
-        $prefix = isset($rule['prefix']) ? trim((string)$rule['prefix']) : '';
-        if ($prefix === '') {
+        $rawPrefix = isset($rule['prefix']) ? (string)$rule['prefix'] : '';
+        if (trim($rawPrefix) === '') {
             continue;
         }
+        $prefix = $rawPrefix;
         $color = isset($rule['color']) ? strtoupper(trim((string)$rule['color'])) : null;
         if ($color && !preg_match('/^#[0-9A-F]{6}$/', $color)) {
             $color = null;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple PHP online todo list application with user authentication and SQLite storage. The interface uses [Bootstrap](https://getbootstrap.com/) for a mobile‑responsive layout.",
   "main": "prevent-save-shortcut.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest && php __tests__/line_rules_test.php"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- keep trailing whitespace intact when sanitizing custom line rule prefixes
- add regression test covering prefix preservation through sanitize/encode/decode
- run PHP line rule test script (npm unavailable in environment)

## Testing
- php __tests__/line_rules_test.php
- npm test (fails: npm not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933b45fb4e4832bae2af79980b60bff)