### PR TITLE
Remove emoji from navbar brand headers

### DIFF
--- a/completed.php
+++ b/completed.php
@@ -40,7 +40,7 @@ $tomorrowFmt = $tomorrow->format('Y-m-d');
 <body class="bg-light">
 <nav class="navbar navbar-light bg-white mb-4">
     <div class="container d-flex justify-content-between align-items-center">
-        <a href="index.php" class="navbar-brand">Otodo <span aria-hidden="true">🙂</span></a>
+        <a href="index.php" class="navbar-brand">Otodo</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#menu" aria-controls="menu">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/settings.php
+++ b/settings.php
@@ -89,7 +89,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <body class="bg-light">
 <nav class="navbar navbar-light bg-white mb-4">
     <div class="container d-flex justify-content-between align-items-center">
-        <a href="index.php" class="navbar-brand">Otodo <span aria-hidden="true">🙂</span></a>
+        <a href="index.php" class="navbar-brand">Otodo</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#menu" aria-controls="menu">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/task.php
+++ b/task.php
@@ -207,7 +207,7 @@ $details_color_attr = htmlspecialchars($details_color);
 <nav class="navbar navbar-light bg-white mb-4">
 
     <div class="container d-flex justify-content-between align-items-center">
-        <a href="index.php" class="navbar-brand">Otodo <span aria-hidden="true">🙂</span></a>
+        <a href="index.php" class="navbar-brand">Otodo</a>
         <div class="d-flex align-items-center gap-2">
             <div class="dropdown">
                 <button class="btn btn-outline-secondary btn-sm" type="button" id="taskMenu" data-bs-toggle="dropdown" aria-expanded="false">&#x2026;</button>


### PR DESCRIPTION
## Summary
- remove smiley emoji markup from navbar brand links on task-related pages

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933bc8f92bc832b95003e1405cb18c6)