### PR TITLE
Add hashtag detection and search support

### DIFF
--- a/add_task.php
+++ b/add_task.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'db.php';
+require_once 'hashtags.php';
 
 if (!isset($_SESSION['user_id'])) {
     header('Location: login.php');
@@ -38,8 +39,11 @@ if ($description !== '') {
         ':due_date' => $due_date,
     ]);
 
+    $id = (int)$db->lastInsertId();
+    $hashtags = collect_hashtags_from_texts($description);
+    sync_task_hashtags($db, $id, (int)$_SESSION['user_id'], $hashtags);
+
     if ($accepts_json) {
-        $id = (int)$db->lastInsertId();
         $priority_labels = [0 => 'None', 1 => 'Low', 2 => 'Medium', 3 => 'High'];
         $priority_classes = [0 => 'text-secondary', 1 => 'text-success', 2 => 'text-warning', 3 => 'text-danger'];
 
@@ -93,6 +97,7 @@ if ($description !== '') {
             'priority_label' => $priority_labels[$priority] ?? 'None',
             'priority_class' => $priority_classes[$priority] ?? 'text-secondary',
             'starred' => 0,
+            'hashtags' => $hashtags,
         ]);
         exit();
     }

--- a/db.php
+++ b/db.php
@@ -42,6 +42,22 @@ function get_db() {
             FOREIGN KEY(user_id) REFERENCES users(id)
         )");
 
+        $db->exec("CREATE TABLE IF NOT EXISTS hashtags (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            UNIQUE(user_id, name),
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )");
+
+        $db->exec("CREATE TABLE IF NOT EXISTS task_hashtags (
+            task_id INTEGER NOT NULL,
+            hashtag_id INTEGER NOT NULL,
+            PRIMARY KEY (task_id, hashtag_id),
+            FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+            FOREIGN KEY(hashtag_id) REFERENCES hashtags(id) ON DELETE CASCADE
+        )");
+
         // Ensure new columns exist for older databases
         $columns = $db->query('PRAGMA table_info(tasks)')->fetchAll(PDO::FETCH_COLUMN, 1);
         if (!in_array('due_date', $columns, true)) {

--- a/hashtags.php
+++ b/hashtags.php
@@ -1,0 +1,158 @@
+<?php
+require_once __DIR__ . '/db.php';
+
+function normalize_hashtag($tag) {
+    $normalized = trim((string)$tag);
+    $normalized = ltrim($normalized, '#');
+    if ($normalized === '') {
+        return '';
+    }
+    return mb_strtolower($normalized, 'UTF-8');
+}
+
+function extract_hashtags_from_text($text) {
+    if (!is_string($text) || $text === '') {
+        return [];
+    }
+    $matches = [];
+    preg_match_all('/#([\p{L}\p{N}_-]+)/u', $text, $matches);
+    if (empty($matches[1])) {
+        return [];
+    }
+    $found = [];
+    foreach ($matches[1] as $match) {
+        $normalized = normalize_hashtag($match);
+        if ($normalized !== '') {
+            $found[$normalized] = true;
+        }
+    }
+    return array_keys($found);
+}
+
+function collect_hashtags_from_texts(...$texts) {
+    $all = [];
+    foreach ($texts as $text) {
+        foreach (extract_hashtags_from_text($text) as $tag) {
+            $all[$tag] = true;
+        }
+    }
+    return array_keys($all);
+}
+
+function get_user_hashtags(PDO $db, $userId) {
+    $stmt = $db->prepare('SELECT name FROM hashtags WHERE user_id = :uid ORDER BY name COLLATE NOCASE');
+    $stmt->execute([':uid' => $userId]);
+    return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+}
+
+function get_task_hashtags(PDO $db, $taskId, $userId) {
+    $stmt = $db->prepare('SELECT h.name FROM task_hashtags th INNER JOIN hashtags h ON h.id = th.hashtag_id WHERE th.task_id = :tid AND h.user_id = :uid ORDER BY h.name COLLATE NOCASE');
+    $stmt->execute([':tid' => $taskId, ':uid' => $userId]);
+    return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+}
+
+function get_hashtags_for_tasks(PDO $db, $userId, array $taskIds) {
+    if (empty($taskIds)) {
+        return [];
+    }
+    $placeholders = implode(',', array_fill(0, count($taskIds), '?'));
+    $params = array_merge([$userId], $taskIds);
+    $sql = "SELECT th.task_id, h.name FROM task_hashtags th INNER JOIN hashtags h ON h.id = th.hashtag_id WHERE h.user_id = ? AND th.task_id IN ($placeholders) ORDER BY h.name COLLATE NOCASE";
+    $stmt = $db->prepare($sql);
+    $stmt->execute($params);
+    $map = [];
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $taskId = (int)$row['task_id'];
+        $map[$taskId][] = $row['name'];
+    }
+    return $map;
+}
+
+function ensure_hashtag_ids(PDO $db, $userId, array $hashtags) {
+    if (empty($hashtags)) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($hashtags), '?'));
+    $query = $db->prepare("SELECT id, name FROM hashtags WHERE user_id = ? AND name IN ($placeholders)");
+    $query->execute(array_merge([$userId], $hashtags));
+    $existing = [];
+    foreach ($query->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $existing[$row['name']] = (int)$row['id'];
+    }
+
+    $insert = $db->prepare('INSERT OR IGNORE INTO hashtags (user_id, name) VALUES (:uid, :name)');
+    foreach ($hashtags as $tag) {
+        if (!isset($existing[$tag])) {
+            $insert->execute([':uid' => $userId, ':name' => $tag]);
+            $existing[$tag] = (int)$db->lastInsertId();
+        }
+    }
+
+    $missing = array_diff($hashtags, array_keys($existing));
+    if (!empty($missing)) {
+        $reload = $db->prepare("SELECT id, name FROM hashtags WHERE user_id = ? AND name IN ($placeholders)");
+        $reload->execute(array_merge([$userId], $hashtags));
+        foreach ($reload->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $existing[$row['name']] = (int)$row['id'];
+        }
+    }
+
+    return $existing;
+}
+
+function sync_task_hashtags(PDO $db, $taskId, $userId, array $hashtags) {
+    $unique = [];
+    foreach ($hashtags as $tag) {
+        $normalized = normalize_hashtag($tag);
+        if ($normalized !== '') {
+            $unique[$normalized] = true;
+        }
+    }
+    $tags = array_keys($unique);
+
+    $db->beginTransaction();
+    try {
+        if (empty($tags)) {
+            $delete = $db->prepare('DELETE FROM task_hashtags WHERE task_id = :tid');
+            $delete->execute([':tid' => $taskId]);
+            $db->commit();
+            return [];
+        }
+
+        $ids = ensure_hashtag_ids($db, $userId, $tags);
+
+        $currentStmt = $db->prepare('SELECT h.id, h.name FROM task_hashtags th INNER JOIN hashtags h ON h.id = th.hashtag_id WHERE th.task_id = :tid');
+        $currentStmt->execute([':tid' => $taskId]);
+        $current = [];
+        foreach ($currentStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $current[$row['name']] = (int)$row['id'];
+        }
+
+        $toRemove = array_diff(array_keys($current), $tags);
+        if (!empty($toRemove)) {
+            $idsToRemove = array_map(function($name) use ($current) { return $current[$name]; }, $toRemove);
+            $placeholders = implode(',', array_fill(0, count($idsToRemove), '?'));
+            $delete = $db->prepare("DELETE FROM task_hashtags WHERE task_id = ? AND hashtag_id IN ($placeholders)");
+            $delete->execute(array_merge([$taskId], $idsToRemove));
+        }
+
+        $toAdd = array_diff($tags, array_keys($current));
+        if (!empty($toAdd)) {
+            $insertLink = $db->prepare('INSERT OR IGNORE INTO task_hashtags (task_id, hashtag_id) VALUES (:tid, :hid)');
+            foreach ($toAdd as $tagName) {
+                $hid = $ids[$tagName] ?? null;
+                if ($hid) {
+                    $insertLink->execute([':tid' => $taskId, ':hid' => $hid]);
+                }
+            }
+        }
+
+        $db->commit();
+        return $tags;
+    } catch (Exception $e) {
+        $db->rollBack();
+        throw $e;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add database tables and helpers for storing task hashtags
- detect and sync hashtags from task text with inline badges and autocomplete suggestions
- surface hashtags on task lists and include them in client-side search filters

## Testing
- php -l db.php
- php -l add_task.php
- php -l task.php
- php -l index.php
- php -l completed.php
- php -l hashtags.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935f35e122c832bbae9af1bd1d04c4c)