### PR TITLE
Add modal to manage hashtags

### DIFF
--- a/hashtags.php
+++ b/hashtags.php
@@ -45,6 +45,19 @@ function get_user_hashtags(PDO $db, $userId) {
     return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
 }
 
+function get_user_hashtags_with_counts(PDO $db, $userId) {
+    $stmt = $db->prepare('SELECT h.id, h.name, COUNT(th.task_id) as usage_count FROM hashtags h LEFT JOIN task_hashtags th ON th.hashtag_id = h.id WHERE h.user_id = :uid GROUP BY h.id, h.name ORDER BY h.name COLLATE NOCASE');
+    $stmt->execute([':uid' => $userId]);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    return array_map(function($row) {
+        return [
+            'id' => (int)$row['id'],
+            'name' => $row['name'],
+            'usage' => (int)$row['usage_count'],
+        ];
+    }, $rows);
+}
+
 function get_task_hashtags(PDO $db, $taskId, $userId) {
     $stmt = $db->prepare('SELECT h.name FROM task_hashtags th INNER JOIN hashtags h ON h.id = th.hashtag_id WHERE th.task_id = :tid AND h.user_id = :uid ORDER BY h.name COLLATE NOCASE');
     $stmt->execute([':tid' => $taskId, ':uid' => $userId]);

--- a/manage_hashtags.php
+++ b/manage_hashtags.php
@@ -1,0 +1,86 @@
+<?php
+require_once 'db.php';
+require_once 'hashtags.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('HTTP/1.1 403 Forbidden');
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'error', 'message' => 'Not logged in']);
+    exit();
+}
+
+function respond($status, $message = '', $extra = [], $code = 200) {
+    if ($code !== 200) {
+        http_response_code($code);
+    }
+    header('Content-Type: application/json');
+    echo json_encode(array_merge([
+        'status' => $status,
+        'message' => $message,
+    ], $extra));
+    exit();
+}
+
+$db = get_db();
+$userId = (int)$_SESSION['user_id'];
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    $tags = get_user_hashtags_with_counts($db, $userId);
+    respond('ok', '', ['hashtags' => $tags]);
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    respond('error', 'Method not allowed', [], 405);
+}
+
+$action = $_POST['action'] ?? '';
+
+switch ($action) {
+    case 'create':
+        $name = normalize_hashtag($_POST['name'] ?? '');
+        if ($name === '') {
+            respond('error', 'Hashtag cannot be empty', [], 400);
+        }
+        ensure_hashtag_ids($db, $userId, [$name]);
+        $hashtags = get_user_hashtags_with_counts($db, $userId);
+        respond('ok', '', ['hashtags' => $hashtags]);
+
+    case 'rename':
+        $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+        $name = normalize_hashtag($_POST['name'] ?? '');
+        if ($id <= 0) {
+            respond('error', 'Invalid hashtag id', [], 400);
+        }
+        if ($name === '') {
+            respond('error', 'Hashtag cannot be empty', [], 400);
+        }
+
+        $exists = $db->prepare('SELECT id FROM hashtags WHERE id = :id AND user_id = :uid');
+        $exists->execute([':id' => $id, ':uid' => $userId]);
+        if (!$exists->fetchColumn()) {
+            respond('error', 'Hashtag not found', [], 404);
+        }
+
+        try {
+            $update = $db->prepare('UPDATE hashtags SET name = :name WHERE id = :id AND user_id = :uid');
+            $update->execute([':name' => $name, ':id' => $id, ':uid' => $userId]);
+        } catch (Exception $e) {
+            respond('error', 'Hashtag already exists', [], 409);
+        }
+
+        $hashtags = get_user_hashtags_with_counts($db, $userId);
+        respond('ok', '', ['hashtags' => $hashtags]);
+
+    case 'delete':
+        $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+        if ($id <= 0) {
+            respond('error', 'Invalid hashtag id', [], 400);
+        }
+        $delete = $db->prepare('DELETE FROM hashtags WHERE id = :id AND user_id = :uid');
+        $delete->execute([':id' => $id, ':uid' => $userId]);
+        $hashtags = get_user_hashtags_with_counts($db, $userId);
+        respond('ok', '', ['hashtags' => $hashtags]);
+
+    default:
+        respond('error', 'Unknown action', [], 400);
+}


### PR DESCRIPTION
## Summary
- add backend endpoint for hashtag CRUD operations with usage counts
- add modal UI accessible from the menu to manage hashtags with create, rename, and delete actions
- style updates to present hashtags with chips, usage indicators, and inline editing

## Testing
- php -l manage_hashtags.php
- php -l hashtags.php
- php -l index.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69374cc93d80832b8363e2e60cd0220b)