### PR TITLE
Handle Esc key for hashtag autocomplete

### DIFF
--- a/task.php
+++ b/task.php
@@ -686,7 +686,7 @@ $user_hashtags_json = json_encode($user_hashtags);
           if (accepted) {
             event.preventDefault();
           }
-        } else if (event.key === 'Escape') {
+        } else if (event.key === 'Escape' || event.key === 'Esc') {
           hideHashtagSuggestions();
         }
       }


### PR DESCRIPTION
## Summary
- ensure pressing Esc also closes the hashtag autocomplete dropdown in task descriptions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937c68bf0b4832bb11963b07219906d)