### PR TITLE
Refine inline hashtag pill appearance

### DIFF
--- a/task.php
+++ b/task.php
@@ -271,8 +271,8 @@ $user_hashtags_json = json_encode($user_hashtags);
             white-space: nowrap;
             border-radius: 999px;
             background: #f3e8ff;
-            box-shadow: 0 0 0 1px #e5d4ff, 0 0 0 6px #f3e8ff;
-            padding-inline: 0;
+            box-shadow: 0 0 0 1px #e5d4ff;
+            padding-inline: 0.2rem;
         }
     </style>
     <title>Task Details</title>


### PR DESCRIPTION
## Summary
- remove the oversized glow around inline hashtag pills in the task description editor
- add minimal padding to keep the hashtag text readable within the pill

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937cb4a96f0832b98a1228e531e83ea)