### PR TITLE
Add configurable date highlighting in task editor

### DIFF
--- a/__tests__/task-details.test.js
+++ b/__tests__/task-details.test.js
@@ -276,6 +276,21 @@ describe('task details editor behaviors', () => {
     expect(details.style.getPropertyValue('--details-text-color')).toBe('#123456');
   });
 
+  test('dates matching configured formats render as inline pills', () => {
+    const details = document.getElementById('detailsInput');
+    const textarea = details.querySelector('textarea');
+    const hidden = document.getElementById('detailsField');
+
+    const editor = initTaskDetailsEditor(details, hidden, jest.fn(), { dateFormats: ['DD MMM YYYY'] });
+
+    textarea.value = 'Ship before 31 Dec 2025 and after 1 Jan 2026.';
+    editor.updateDetails();
+
+    const preview = details.querySelector('code');
+    expect(preview.innerHTML).toContain('<span class="inline-date">31 Dec 2025</span>');
+    expect(preview.innerHTML).toContain('<span class="inline-date">1 Jan 2026</span>');
+  });
+
   test('capitalization toggle uppercases lines that match a rule while leaving others untouched', () => {
     const details = document.getElementById('detailsInput');
     const textarea = details.querySelector('textarea');

--- a/date_formats.php
+++ b/date_formats.php
@@ -1,0 +1,53 @@
+<?php
+
+function get_default_date_formats(): array {
+    return ['DD MMM YYYY'];
+}
+
+function sanitize_date_formats_input($input): array {
+    if (is_string($input)) {
+        $lines = preg_split('/\r\n|\r|\n/', $input);
+    } elseif (is_array($input)) {
+        $lines = $input;
+    } else {
+        $lines = [];
+    }
+
+    $cleaned = [];
+    foreach ($lines as $line) {
+        $format = trim((string)$line);
+        if ($format === '') {
+            continue;
+        }
+
+        if (!preg_match('/(DD|D|MMMM|MMM|MM|M|YYYY|YY)/', $format)) {
+            continue;
+        }
+
+        $cleaned[] = mb_substr($format, 0, 60);
+    }
+
+    $unique = array_values(array_unique($cleaned));
+    if (empty($unique)) {
+        return get_default_date_formats();
+    }
+    return $unique;
+}
+
+function encode_date_formats_for_storage(array $formats): string {
+    return json_encode(array_values($formats));
+}
+
+function decode_date_formats_from_storage(?string $value): array {
+    if (!$value) {
+        return get_default_date_formats();
+    }
+
+    $decoded = json_decode($value, true);
+    if (!is_array($decoded)) {
+        return get_default_date_formats();
+    }
+
+    return sanitize_date_formats_input($decoded);
+}
+

--- a/db.php
+++ b/db.php
@@ -27,7 +27,8 @@ function get_db() {
             default_priority INTEGER NOT NULL DEFAULT 0,
             line_rules TEXT,
             details_color TEXT,
-            capitalize_sentences INTEGER NOT NULL DEFAULT 1
+            capitalize_sentences INTEGER NOT NULL DEFAULT 1,
+            date_formats TEXT
         )");
 
         $db->exec("CREATE TABLE IF NOT EXISTS tasks (
@@ -89,6 +90,9 @@ function get_db() {
         }
         if (!in_array('capitalize_sentences', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN capitalize_sentences INTEGER NOT NULL DEFAULT 1');
+        }
+        if (!in_array('date_formats', $userColumns, true)) {
+            $db->exec('ALTER TABLE users ADD COLUMN date_formats TEXT');
         }
 
         if (PHP_OS_FAMILY === 'Windows' && file_exists($databaseFile)) {

--- a/login.php
+++ b/login.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'db.php';
 require_once 'line_rules.php';
+require_once 'date_formats.php';
 
 if (isset($_SESSION['user_id'])) {
     header('Location: index.php');
@@ -14,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($username === '' || $password === '') {
         $error = 'Please fill in all fields';
     } else {
-        $stmt = get_db()->prepare('SELECT id, password, location, default_priority, line_rules, details_color, capitalize_sentences FROM users WHERE username = :username');
+        $stmt = get_db()->prepare('SELECT id, password, location, default_priority, line_rules, details_color, capitalize_sentences, date_formats FROM users WHERE username = :username');
         $stmt->execute([':username' => $username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password'])) {
@@ -25,6 +26,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['line_rules'] = decode_line_rules_from_storage($user['line_rules'] ?? '');
             $_SESSION['details_color'] = normalize_editor_color($user['details_color'] ?? '#212529');
             $_SESSION['capitalize_sentences'] = isset($user['capitalize_sentences']) ? (int)$user['capitalize_sentences'] === 1 : true;
+            $_SESSION['date_formats'] = decode_date_formats_from_storage($user['date_formats'] ?? '');
             header('Location: index.php');
             exit();
         } else {

--- a/register.php
+++ b/register.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'db.php';
 require_once 'line_rules.php';
+require_once 'date_formats.php';
 
 if (isset($_SESSION['user_id'])) {
     header('Location: index.php');
@@ -17,13 +18,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         try {
             $hash = password_hash($password, PASSWORD_DEFAULT);
             $defaultRules = encode_line_rules_for_storage(get_default_line_rules());
-            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority, line_rules, details_color, capitalize_sentences) VALUES (:username, :password, 0, :rules, :color, :capitalize)');
+            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority, line_rules, details_color, capitalize_sentences, date_formats) VALUES (:username, :password, 0, :rules, :color, :capitalize, :date_formats)');
             $stmt->execute([
                 ':username' => $username,
                 ':password' => $hash,
                 ':rules' => $defaultRules,
                 ':color' => '#212529',
                 ':capitalize' => 1,
+                ':date_formats' => encode_date_formats_for_storage(get_default_date_formats()),
             ]);
             header('Location: login.php');
             exit();

--- a/task.php
+++ b/task.php
@@ -2,6 +2,7 @@
 require_once 'db.php';
 require_once 'line_rules.php';
 require_once 'hashtags.php';
+require_once 'date_formats.php';
 
 if (!isset($_SESSION['user_id'])) {
     header('Location: login.php');
@@ -82,9 +83,11 @@ if ($p < 0 || $p > 3) { $p = 0; }
 $line_rules = $_SESSION['line_rules'] ?? get_default_line_rules();
 $details_color = normalize_editor_color($_SESSION['details_color'] ?? '#212529');
 $capitalize_sentences = isset($_SESSION['capitalize_sentences']) ? (bool)$_SESSION['capitalize_sentences'] : true;
+$date_formats = $_SESSION['date_formats'] ?? get_default_date_formats();
 $line_rules_json = htmlspecialchars(json_encode($line_rules));
 $details_color_attr = htmlspecialchars($details_color);
 $capitalize_sentences_attr = $capitalize_sentences ? 'true' : 'false';
+$date_formats_attr = htmlspecialchars(json_encode($date_formats));
 $task_hashtags_json = json_encode($task_hashtags);
 $user_hashtags_json = json_encode($user_hashtags);
 ?>
@@ -274,6 +277,16 @@ $user_hashtags_json = json_encode($user_hashtags);
             box-shadow: 0 0 0 1px #e5d4ff;
             padding-inline: 0;
         }
+        .inline-date {
+            position: relative;
+            color: #0d6efd;
+            font-weight: 600;
+            white-space: nowrap;
+            border-radius: 999px;
+            background: #e7f1ff;
+            box-shadow: 0 0 0 1px #bfd7ff;
+            padding: 0.05rem 0.35rem;
+        }
     </style>
     <title>Task Details</title>
 </head>
@@ -349,7 +362,7 @@ $user_hashtags_json = json_encode($user_hashtags);
         </div>
         <div class="mb-3">
             <label class="form-label">Description</label>
-            <div id="detailsInput" class="prism-editor" data-language="html" data-line-rules="<?=$line_rules_json?>" data-text-color="<?=$details_color_attr?>" data-capitalize-sentences="<?=$capitalize_sentences_attr?>" style="--details-text-color: <?=$details_color_attr?>;">
+            <div id="detailsInput" class="prism-editor" data-language="html" data-line-rules="<?=$line_rules_json?>" data-text-color="<?=$details_color_attr?>" data-capitalize-sentences="<?=$capitalize_sentences_attr?>" data-date-formats="<?=$date_formats_attr?>" style="--details-text-color: <?=$details_color_attr?>;">
                 <textarea class="prism-editor__textarea" spellcheck="false"><?=htmlspecialchars($task['details'] ?? '')?></textarea>
                 <pre class="prism-editor__preview"><code class="language-markup"></code></pre>
             </div>
@@ -748,6 +761,7 @@ $user_hashtags_json = json_encode($user_hashtags);
   if (details && detailsField && window.initTaskDetailsEditor) {
     let rules = [];
     const capitalizeSentences = details.dataset.capitalizeSentences === 'true';
+    let dateFormats = [];
     try {
       rules = JSON.parse(details.dataset.lineRules || '[]');
       if (!Array.isArray(rules)) {
@@ -756,10 +770,19 @@ $user_hashtags_json = json_encode($user_hashtags);
     } catch (err) {
       rules = [];
     }
+    try {
+      dateFormats = JSON.parse(details.dataset.dateFormats || '[]');
+      if (!Array.isArray(dateFormats)) {
+        dateFormats = [];
+      }
+    } catch (err) {
+      dateFormats = [];
+    }
     const editor = initTaskDetailsEditor(details, detailsField, scheduleSave, {
       lineRules: rules,
       textColor: details.dataset.textColor,
-      capitalizeSentences: capitalizeSentences
+      capitalizeSentences: capitalizeSentences,
+      dateFormats: dateFormats
     });
     if (editor && typeof editor.updateDetails === 'function') {
       const baseUpdate = editor.updateDetails;


### PR DESCRIPTION
## Summary
- add configurable date format list to user settings and store it alongside other editor preferences
- highlight matching dates in the task description editor with a pill-style badge using the configured formats
- update task editor initialization and tests to cover date highlighting

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937dda7dab8832b84c87d45436136ed)