### PR TITLE
Refine date format defaults and settings copy

### DIFF
--- a/date_formats.php
+++ b/date_formats.php
@@ -1,7 +1,14 @@
 <?php
 
 function get_default_date_formats(): array {
-    return ['DD MMM YYYY'];
+    return [
+        'DD MMM YYYY',
+        'DD MMM YY',
+        'DD/MM/YYYY',
+        'DD/MM/YY',
+        'DD-MM-YYYY',
+        'DD-MM-YY',
+    ];
 }
 
 function sanitize_date_formats_input($input): array {

--- a/db.php
+++ b/db.php
@@ -27,6 +27,8 @@ function get_db() {
             default_priority INTEGER NOT NULL DEFAULT 0,
             line_rules TEXT,
             details_color TEXT,
+            hashtag_color TEXT,
+            date_color TEXT,
             capitalize_sentences INTEGER NOT NULL DEFAULT 1,
             date_formats TEXT
         )");
@@ -87,6 +89,12 @@ function get_db() {
         }
         if (!in_array('details_color', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN details_color TEXT');
+        }
+        if (!in_array('hashtag_color', $userColumns, true)) {
+            $db->exec('ALTER TABLE users ADD COLUMN hashtag_color TEXT');
+        }
+        if (!in_array('date_color', $userColumns, true)) {
+            $db->exec('ALTER TABLE users ADD COLUMN date_color TEXT');
         }
         if (!in_array('capitalize_sentences', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN capitalize_sentences INTEGER NOT NULL DEFAULT 1');

--- a/line_rules.php
+++ b/line_rules.php
@@ -10,12 +10,25 @@ function get_default_line_rules() {
     ];
 }
 
-function normalize_editor_color($color) {
+function normalize_hex_color($color, $default = '#212529') {
     $trimmed = strtoupper(trim($color ?? ''));
     if (!preg_match('/^#[0-9A-F]{6}$/', $trimmed)) {
-        return '#212529';
+        return $default;
     }
     return $trimmed;
+}
+
+function hex_to_rgba($hex, $alpha) {
+    $color = normalize_hex_color($hex, '#000000');
+    $alphaClamped = max(0, min(1, (float)$alpha));
+    $r = hexdec(substr($color, 1, 2));
+    $g = hexdec(substr($color, 3, 2));
+    $b = hexdec(substr($color, 5, 2));
+    return sprintf('rgba(%d, %d, %d, %.3f)', $r, $g, $b, $alphaClamped);
+}
+
+function normalize_editor_color($color) {
+    return normalize_hex_color($color, '#212529');
 }
 
 function sanitize_line_rules($rules) {

--- a/login.php
+++ b/login.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($username === '' || $password === '') {
         $error = 'Please fill in all fields';
     } else {
-        $stmt = get_db()->prepare('SELECT id, password, location, default_priority, line_rules, details_color, capitalize_sentences, date_formats FROM users WHERE username = :username');
+        $stmt = get_db()->prepare('SELECT id, password, location, default_priority, line_rules, details_color, hashtag_color, date_color, capitalize_sentences, date_formats FROM users WHERE username = :username');
         $stmt->execute([':username' => $username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password'])) {
@@ -25,6 +25,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['default_priority'] = (int)($user['default_priority'] ?? 0);
             $_SESSION['line_rules'] = decode_line_rules_from_storage($user['line_rules'] ?? '');
             $_SESSION['details_color'] = normalize_editor_color($user['details_color'] ?? '#212529');
+            $_SESSION['hashtag_color'] = normalize_hex_color($user['hashtag_color'] ?? '#6F42C1', '#6F42C1');
+            $_SESSION['date_color'] = normalize_hex_color($user['date_color'] ?? '#FDA90D', '#FDA90D');
             $_SESSION['capitalize_sentences'] = isset($user['capitalize_sentences']) ? (int)$user['capitalize_sentences'] === 1 : true;
             $_SESSION['date_formats'] = decode_date_formats_from_storage($user['date_formats'] ?? '');
             header('Location: index.php');

--- a/register.php
+++ b/register.php
@@ -18,12 +18,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         try {
             $hash = password_hash($password, PASSWORD_DEFAULT);
             $defaultRules = encode_line_rules_for_storage(get_default_line_rules());
-            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority, line_rules, details_color, capitalize_sentences, date_formats) VALUES (:username, :password, 0, :rules, :color, :capitalize, :date_formats)');
+            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority, line_rules, details_color, hashtag_color, date_color, capitalize_sentences, date_formats) VALUES (:username, :password, 0, :rules, :color, :hashtag_color, :date_color, :capitalize, :date_formats)');
             $stmt->execute([
                 ':username' => $username,
                 ':password' => $hash,
                 ':rules' => $defaultRules,
                 ':color' => '#212529',
+                ':hashtag_color' => '#6F42C1',
+                ':date_color' => '#FDA90D',
                 ':capitalize' => 1,
                 ':date_formats' => encode_date_formats_for_storage(get_default_date_formats()),
             ]);

--- a/settings.php
+++ b/settings.php
@@ -15,6 +15,8 @@ $username = $_SESSION['username'] ?? '';
 $location = $_SESSION['location'] ?? '';
 $default_priority = (int)($_SESSION['default_priority'] ?? 0);
 $details_color = $_SESSION['details_color'] ?? '#212529';
+$hashtag_color = normalize_hex_color($_SESSION['hashtag_color'] ?? '#6F42C1', '#6F42C1');
+$date_color = normalize_hex_color($_SESSION['date_color'] ?? '#FDA90D', '#FDA90D');
 $line_rules = $_SESSION['line_rules'] ?? get_default_line_rules();
 $capitalize_sentences = isset($_SESSION['capitalize_sentences']) ? (bool)$_SESSION['capitalize_sentences'] : true;
 $date_formats = $_SESSION['date_formats'] ?? get_default_date_formats();
@@ -36,6 +38,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $line_rules = get_default_line_rules();
     }
     $details_color = normalize_editor_color($_POST['details_color'] ?? $details_color);
+    $hashtag_color = normalize_hex_color($_POST['hashtag_color'] ?? $hashtag_color, '#6F42C1');
+    $date_color = normalize_hex_color($_POST['date_color'] ?? $date_color, '#FDA90D');
     $capitalize_sentences = isset($_POST['capitalize_sentences']);
     $date_formats_input = $_POST['date_formats'] ?? '';
     $date_formats = sanitize_date_formats_input($date_formats_input);
@@ -46,7 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         try {
             if ($password !== '') {
                 $hash = password_hash($password, PASSWORD_DEFAULT);
-                $stmt = $db->prepare('UPDATE users SET username = :username, password = :password, location = :loc, default_priority = :pri, line_rules = :rules, details_color = :color, capitalize_sentences = :capitalize, date_formats = :date_formats WHERE id = :id');
+                $stmt = $db->prepare('UPDATE users SET username = :username, password = :password, location = :loc, default_priority = :pri, line_rules = :rules, details_color = :color, hashtag_color = :hashtag_color, date_color = :date_color, capitalize_sentences = :capitalize, date_formats = :date_formats WHERE id = :id');
                 $stmt->execute([
                     ':username' => $username,
                     ':password' => $hash,
@@ -54,18 +58,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     ':pri' => $default_priority,
                     ':rules' => encode_line_rules_for_storage($line_rules),
                     ':color' => $details_color,
+                    ':hashtag_color' => $hashtag_color,
+                    ':date_color' => $date_color,
                     ':capitalize' => $capitalize_sentences ? 1 : 0,
                     ':date_formats' => encode_date_formats_for_storage($date_formats),
                     ':id' => $_SESSION['user_id'],
                 ]);
             } else {
-                $stmt = $db->prepare('UPDATE users SET username = :username, location = :loc, default_priority = :pri, line_rules = :rules, details_color = :color, capitalize_sentences = :capitalize, date_formats = :date_formats WHERE id = :id');
+                $stmt = $db->prepare('UPDATE users SET username = :username, location = :loc, default_priority = :pri, line_rules = :rules, details_color = :color, hashtag_color = :hashtag_color, date_color = :date_color, capitalize_sentences = :capitalize, date_formats = :date_formats WHERE id = :id');
                 $stmt->execute([
                     ':username' => $username,
                     ':loc' => $location !== '' ? $location : null,
                     ':pri' => $default_priority,
                     ':rules' => encode_line_rules_for_storage($line_rules),
                     ':color' => $details_color,
+                    ':hashtag_color' => $hashtag_color,
+                    ':date_color' => $date_color,
                     ':capitalize' => $capitalize_sentences ? 1 : 0,
                     ':date_formats' => encode_date_formats_for_storage($date_formats),
                     ':id' => $_SESSION['user_id'],
@@ -76,6 +84,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['default_priority'] = $default_priority;
             $_SESSION['line_rules'] = $line_rules;
             $_SESSION['details_color'] = $details_color;
+            $_SESSION['hashtag_color'] = $hashtag_color;
+            $_SESSION['date_color'] = $date_color;
             $_SESSION['capitalize_sentences'] = $capitalize_sentences ? 1 : 0;
             $_SESSION['date_formats'] = $date_formats;
             $message = 'Settings saved';
@@ -164,9 +174,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <input type="color" name="details_color" id="details_color" class="form-control form-control-color" value="<?=htmlspecialchars($details_color ?? '#212529')?>" title="Pick a color for the task description editor">
         </div>
         <div class="mb-3">
+            <label class="form-label" for="hashtag_color">Hashtag highlight color</label>
+            <input type="color" name="hashtag_color" id="hashtag_color" class="form-control form-control-color" value="<?=htmlspecialchars($hashtag_color ?? '#6F42C1')?>" title="Pick a color for hashtags in the description preview">
+            <div class="form-text">Background and border shades will adapt to this color.</div>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="date_color">Date highlight color</label>
+            <input type="color" name="date_color" id="date_color" class="form-control form-control-color" value="<?=htmlspecialchars($date_color ?? '#FDA90D')?>" title="Pick a color for highlighted dates">
+            <div class="form-text">Background and border shades will adapt to this color.</div>
+        </div>
+        <div class="mb-3">
             <label class="form-label" for="date_formats">Date formats to highlight</label>
             <textarea class="form-control" id="date_formats" name="date_formats" rows="3" placeholder="DD MMM YYYY&#10;YYYY-MM-DD"><?=htmlspecialchars(implode("\n", $date_formats))?></textarea>
-            <div class="form-text">One format per line. Supported tokens: D, DD, M, MM, MMM, MMMM, YY, YYYY. Default: DD MMM YYYY (for example, 31 Dec 2025).</div>
+            <div class="form-text">One format per line. Supported tokens: D, DD, M, MM, MMM, MMMM, YY, YYYY. Defaults include DD MMM YYYY and DD/MM/YYYY (for example, 31 Dec 2025).</div>
         </div>
         <div class="form-check form-switch mb-4">
             <input class="form-check-input" type="checkbox" role="switch" id="capitalize_sentences" name="capitalize_sentences" <?=$capitalize_sentences ? 'checked' : ''?>>

--- a/task.php
+++ b/task.php
@@ -82,10 +82,22 @@ $p = (int)($task['priority'] ?? 0);
 if ($p < 0 || $p > 3) { $p = 0; }
 $line_rules = $_SESSION['line_rules'] ?? get_default_line_rules();
 $details_color = normalize_editor_color($_SESSION['details_color'] ?? '#212529');
+$hashtag_color = normalize_hex_color($_SESSION['hashtag_color'] ?? '#6F42C1', '#6F42C1');
+$date_color = normalize_hex_color($_SESSION['date_color'] ?? '#FDA90D', '#FDA90D');
+$hashtag_background = hex_to_rgba($hashtag_color, 0.12);
+$hashtag_border = hex_to_rgba($hashtag_color, 0.25);
+$date_background = hex_to_rgba($date_color, 0.12);
+$date_border = hex_to_rgba($date_color, 0.25);
 $capitalize_sentences = isset($_SESSION['capitalize_sentences']) ? (bool)$_SESSION['capitalize_sentences'] : true;
 $date_formats = $_SESSION['date_formats'] ?? get_default_date_formats();
 $line_rules_json = htmlspecialchars(json_encode($line_rules));
 $details_color_attr = htmlspecialchars($details_color);
+$hashtag_color_attr = htmlspecialchars($hashtag_color);
+$hashtag_background_attr = htmlspecialchars($hashtag_background);
+$hashtag_border_attr = htmlspecialchars($hashtag_border);
+$date_color_attr = htmlspecialchars($date_color);
+$date_background_attr = htmlspecialchars($date_background);
+$date_border_attr = htmlspecialchars($date_border);
 $capitalize_sentences_attr = $capitalize_sentences ? 'true' : 'false';
 $date_formats_attr = htmlspecialchars(json_encode($date_formats));
 $task_hashtags_json = json_encode($task_hashtags);
@@ -98,6 +110,14 @@ $user_hashtags_json = json_encode($user_hashtags);
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
+        :root {
+            --inline-hashtag-color: <?=$hashtag_color_attr?>;
+            --inline-hashtag-background: <?=$hashtag_background_attr?>;
+            --inline-hashtag-border: <?=$hashtag_border_attr?>;
+            --inline-date-color: <?=$date_color_attr?>;
+            --inline-date-background: <?=$date_background_attr?>;
+            --inline-date-border: <?=$date_border_attr?>;
+        }
         #prioritySelect option.bg-secondary-subtle:hover,
         #prioritySelect option.bg-secondary-subtle:focus,
         #prioritySelect option.bg-secondary-subtle:active {
@@ -269,22 +289,22 @@ $user_hashtags_json = json_encode($user_hashtags);
         }
         .inline-hashtag {
             position: relative;
-            color: #6f42c1;
+            color: var(--inline-hashtag-color);
             font-weight: 600;
             white-space: nowrap;
             border-radius: 2px;
-            background: #f3e8ff;
-            box-shadow: 0 0 0 1px #e5d4ff;
+            background: var(--inline-hashtag-background);
+            box-shadow: 0 0 0 1px var(--inline-hashtag-border);
             padding-inline: 0;
         }
         .inline-date {
             position: relative;
-            color: #fda90d;
+            color: var(--inline-date-color);
             font-weight: 600;
             white-space: nowrap;
             border-radius: 2px;
-            background: #fff2e7;
-            box-shadow: 0 0 0 1px #ffead4;
+            background: var(--inline-date-background);
+            box-shadow: 0 0 0 1px var(--inline-date-border);
             padding: 0;
         }
     </style>


### PR DESCRIPTION
## Summary
- expand the built-in date formats list to include common day/month variants by default
- update settings help text to reflect the broader defaults for date highlighting

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e3887c88832bb127f7a0c512f793)