### PR TITLE
Allow tab key to accept hashtag autocomplete

### DIFF
--- a/task.php
+++ b/task.php
@@ -719,7 +719,7 @@ $user_hashtags_json = json_encode($user_hashtags);
           event.preventDefault();
           const delta = event.key === 'ArrowDown' ? 1 : -1;
           setActiveSuggestion(activeSuggestionIndex + delta);
-        } else if (event.key === 'Enter') {
+        } else if (event.key === 'Enter' || event.key === 'Tab') {
           const accepted = acceptActiveSuggestion();
           if (accepted) {
             event.preventDefault();


### PR DESCRIPTION
## Summary
- allow the Tab key to accept the active hashtag suggestion when autocomplete is visible
- prevent the default tab behavior so selecting a suggestion does not insert a tab character

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938966fc9a8832baed62a0eeb07214d)