### PR TITLE
Add configurable text expanders for task descriptions

### DIFF
--- a/db.php
+++ b/db.php
@@ -30,7 +30,8 @@ function get_db() {
             hashtag_color TEXT,
             date_color TEXT,
             capitalize_sentences INTEGER NOT NULL DEFAULT 1,
-            date_formats TEXT
+            date_formats TEXT,
+            text_expanders TEXT
         )");
 
         $db->exec("CREATE TABLE IF NOT EXISTS tasks (
@@ -101,6 +102,9 @@ function get_db() {
         }
         if (!in_array('date_formats', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN date_formats TEXT');
+        }
+        if (!in_array('text_expanders', $userColumns, true)) {
+            $db->exec('ALTER TABLE users ADD COLUMN text_expanders TEXT');
         }
 
         if (PHP_OS_FAMILY === 'Windows' && file_exists($databaseFile)) {

--- a/login.php
+++ b/login.php
@@ -2,6 +2,7 @@
 require_once 'db.php';
 require_once 'line_rules.php';
 require_once 'date_formats.php';
+require_once 'text_expanders.php';
 
 if (isset($_SESSION['user_id'])) {
     header('Location: index.php');
@@ -15,7 +16,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($username === '' || $password === '') {
         $error = 'Please fill in all fields';
     } else {
-        $stmt = get_db()->prepare('SELECT id, password, location, default_priority, line_rules, details_color, hashtag_color, date_color, capitalize_sentences, date_formats FROM users WHERE username = :username');
+        $stmt = get_db()->prepare('SELECT id, password, location, default_priority, line_rules, details_color, hashtag_color, date_color, capitalize_sentences, date_formats, text_expanders FROM users WHERE username = :username');
         $stmt->execute([':username' => $username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password'])) {
@@ -29,6 +30,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['date_color'] = normalize_hex_color($user['date_color'] ?? '#FDA90D', '#FDA90D');
             $_SESSION['capitalize_sentences'] = isset($user['capitalize_sentences']) ? (int)$user['capitalize_sentences'] === 1 : true;
             $_SESSION['date_formats'] = decode_date_formats_from_storage($user['date_formats'] ?? '');
+            $_SESSION['text_expanders'] = decode_text_expanders_from_storage($user['text_expanders'] ?? '');
             header('Location: index.php');
             exit();
         } else {

--- a/register.php
+++ b/register.php
@@ -2,6 +2,7 @@
 require_once 'db.php';
 require_once 'line_rules.php';
 require_once 'date_formats.php';
+require_once 'text_expanders.php';
 
 if (isset($_SESSION['user_id'])) {
     header('Location: index.php');
@@ -18,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         try {
             $hash = password_hash($password, PASSWORD_DEFAULT);
             $defaultRules = encode_line_rules_for_storage(get_default_line_rules());
-            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority, line_rules, details_color, hashtag_color, date_color, capitalize_sentences, date_formats) VALUES (:username, :password, 0, :rules, :color, :hashtag_color, :date_color, :capitalize, :date_formats)');
+            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority, line_rules, details_color, hashtag_color, date_color, capitalize_sentences, date_formats, text_expanders) VALUES (:username, :password, 0, :rules, :color, :hashtag_color, :date_color, :capitalize, :date_formats, :text_expanders)');
             $stmt->execute([
                 ':username' => $username,
                 ':password' => $hash,
@@ -28,6 +29,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 ':date_color' => '#FDA90D',
                 ':capitalize' => 1,
                 ':date_formats' => encode_date_formats_for_storage(get_default_date_formats()),
+                ':text_expanders' => encode_text_expanders_for_storage([]),
             ]);
             header('Location: login.php');
             exit();

--- a/task.php
+++ b/task.php
@@ -3,6 +3,7 @@ require_once 'db.php';
 require_once 'line_rules.php';
 require_once 'hashtags.php';
 require_once 'date_formats.php';
+require_once 'text_expanders.php';
 
 if (!isset($_SESSION['user_id'])) {
     header('Location: login.php');
@@ -90,6 +91,7 @@ $date_background = hex_to_rgba($date_color, 0.12);
 $date_border = hex_to_rgba($date_color, 0.25);
 $capitalize_sentences = isset($_SESSION['capitalize_sentences']) ? (bool)$_SESSION['capitalize_sentences'] : true;
 $date_formats = $_SESSION['date_formats'] ?? get_default_date_formats();
+$text_expanders = $_SESSION['text_expanders'] ?? [];
 $line_rules_json = htmlspecialchars(json_encode($line_rules));
 $details_color_attr = htmlspecialchars($details_color);
 $hashtag_color_attr = htmlspecialchars($hashtag_color);
@@ -100,6 +102,7 @@ $date_background_attr = htmlspecialchars($date_background);
 $date_border_attr = htmlspecialchars($date_border);
 $capitalize_sentences_attr = $capitalize_sentences ? 'true' : 'false';
 $date_formats_attr = htmlspecialchars(json_encode($date_formats));
+$text_expanders_attr = htmlspecialchars(json_encode($text_expanders));
 $task_hashtags_json = json_encode($task_hashtags);
 $user_hashtags_json = json_encode($user_hashtags);
 ?>
@@ -307,6 +310,25 @@ $user_hashtags_json = json_encode($user_hashtags);
             box-shadow: 0 0 0 1px var(--inline-date-border);
             padding: 0;
         }
+        .expander-suggestions {
+            position: absolute;
+            right: 0.75rem;
+            bottom: 0.75rem;
+            min-width: 260px;
+            max-width: 360px;
+            border: 1px solid #e9ecef;
+            border-radius: 0.5rem;
+            background: #fff;
+            box-shadow: 0 0.75rem 1.5rem rgba(0,0,0,0.08);
+            padding: 0.5rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+            z-index: 10;
+        }
+        .expander-suggestions .btn.active {
+            background-color: #e7f1ff;
+        }
     </style>
     <title>Task Details</title>
 </head>
@@ -382,7 +404,7 @@ $user_hashtags_json = json_encode($user_hashtags);
         </div>
         <div class="mb-3">
             <label class="form-label">Description</label>
-            <div id="detailsInput" class="prism-editor" data-language="html" data-line-rules="<?=$line_rules_json?>" data-text-color="<?=$details_color_attr?>" data-capitalize-sentences="<?=$capitalize_sentences_attr?>" data-date-formats="<?=$date_formats_attr?>" style="--details-text-color: <?=$details_color_attr?>;">
+            <div id="detailsInput" class="prism-editor" data-language="html" data-line-rules="<?=$line_rules_json?>" data-text-color="<?=$details_color_attr?>" data-capitalize-sentences="<?=$capitalize_sentences_attr?>" data-date-formats="<?=$date_formats_attr?>" data-text-expanders="<?=$text_expanders_attr?>" style="--details-text-color: <?=$details_color_attr?>;">
                 <textarea class="prism-editor__textarea" spellcheck="false"><?=htmlspecialchars($task['details'] ?? '')?></textarea>
                 <pre class="prism-editor__preview"><code class="language-markup"></code></pre>
             </div>
@@ -782,6 +804,7 @@ $user_hashtags_json = json_encode($user_hashtags);
     let rules = [];
     const capitalizeSentences = details.dataset.capitalizeSentences === 'true';
     let dateFormats = [];
+    let textExpanders = [];
     try {
       rules = JSON.parse(details.dataset.lineRules || '[]');
       if (!Array.isArray(rules)) {
@@ -798,11 +821,20 @@ $user_hashtags_json = json_encode($user_hashtags);
     } catch (err) {
       dateFormats = [];
     }
+    try {
+      textExpanders = JSON.parse(details.dataset.textExpanders || '[]');
+      if (!Array.isArray(textExpanders)) {
+        textExpanders = [];
+      }
+    } catch (err) {
+      textExpanders = [];
+    }
     const editor = initTaskDetailsEditor(details, detailsField, scheduleSave, {
       lineRules: rules,
       textColor: details.dataset.textColor,
       capitalizeSentences: capitalizeSentences,
-      dateFormats: dateFormats
+      dateFormats: dateFormats,
+      textExpanders: textExpanders
     });
     if (editor && typeof editor.updateDetails === 'function') {
       const baseUpdate = editor.updateDetails;

--- a/text_expanders.php
+++ b/text_expanders.php
@@ -1,0 +1,37 @@
+<?php
+
+function sanitize_text_expanders($input) {
+    if (!is_array($input)) {
+        return [];
+    }
+
+    $normalized = [];
+    foreach ($input as $item) {
+        if (!is_array($item)) {
+            continue;
+        }
+        $shortcut = trim((string)($item['shortcut'] ?? ''));
+        $expansion = trim((string)($item['expansion'] ?? ''));
+        if ($shortcut === '' || $expansion === '') {
+            continue;
+        }
+        $normalized[] = [
+            'shortcut' => $shortcut,
+            'expansion' => $expansion,
+        ];
+    }
+
+    return $normalized;
+}
+
+function encode_text_expanders_for_storage($expanders) {
+    return json_encode(sanitize_text_expanders($expanders));
+}
+
+function decode_text_expanders_from_storage($value) {
+    if (!is_string($value) || $value === '') {
+        return [];
+    }
+    $decoded = json_decode($value, true);
+    return sanitize_text_expanders($decoded);
+}


### PR DESCRIPTION
## Summary
- add per-user text expander storage and management UI in settings
- persist expanders through registration/login and expose them to the task editor
- surface autocomplete suggestions in the description editor that insert the configured expansions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a97a10e50832ba3288cd687ce01f2)