### PR TITLE
Prevent tab insertion when accepting hashtag suggestion

### DIFF
--- a/task-details.js
+++ b/task-details.js
@@ -456,6 +456,9 @@
     });
 
     textarea.addEventListener('keydown', function(e) {
+      if (e.defaultPrevented) {
+        return;
+      }
       if (!expanderSuggestions.classList.contains('d-none')) {
         const tokenRange = findCurrentToken();
         if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {


### PR DESCRIPTION
## Summary
- ignore keydown handling when the event has already been prevented
- avoid inserting a literal tab after accepting hashtag autocomplete suggestions

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9e2dfaa8832bbedfeac0bab3765c)